### PR TITLE
Better high precision projection

### DIFF
--- a/lib/shaders/xform.glsl
+++ b/lib/shaders/xform.glsl
@@ -1,8 +1,8 @@
 #pragma glslify: export(computePosition)
 vec4 computePosition(vec2 posHi, vec2 posLo, vec2 scHi, vec2 scLo, vec2 trHi, vec2 trLo, vec2 screenScale, vec2 screenOffset) {
-  return vec4(scHi * posHi + trHi
-            + scLo * posHi + trLo
-            + scHi * posLo
-            + scLo * posLo
+  return vec4((posHi + trHi) * scHi
+            + (posLo + trLo) * scHi
+            + (posHi + trHi) * scLo
+            + (posLo + trLo) * scLo
             + screenScale * screenOffset, 0, 1);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gl-scatter2d-fancy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Fancy and slow scatter plots",
   "main": "scatter-fancy.js",
   "scripts": {

--- a/scatter-fancy.js
+++ b/scatter-fancy.js
@@ -140,8 +140,8 @@ var proto = GLScatterFancy.prototype
 
     var scaleX = 2 * boundX / dataX
     var scaleY = 2 * boundY / dataY
-    var translateX = 2 * (bounds[0] - dataBox[0]) / dataX - 1
-    var translateY = 2 * (bounds[1] - dataBox[1]) / dataY - 1
+    var translateX = (bounds[0] - dataBox[0] - 0.5 * dataX) / boundX
+    var translateY = (bounds[1] - dataBox[1] - 0.5 * dataY) / boundY
 
     SCALE_HI[0] = scaleX
     SCALE_LO[0] = scaleX - SCALE_HI[0]


### PR DESCRIPTION
Use smaller magnitude numbers by first translating, then doing the scaling. It's not immediately obvious, but the `translateX` / `translateY` values are simply divided by the scaler in JS (then simplified to retain precision) to allow the swap of `position * scale + translation` with `(position + translation') * scale` in the vertex shader code.